### PR TITLE
Checks

### DIFF
--- a/forge/server/modelToXML.rkt
+++ b/forge/server/modelToXML.rkt
@@ -90,6 +90,12 @@ here-string-delimiter
                         "<atom label=\"&#128557;\"/><atom label=\"&#128542;\"/><atom label=\"&#128546;\"/><atom label=\"&#128551;\"/><atom label=\"&#128558;\"/>\n"
                         "</sig>\n"
                         "</instance>\n</alloy>")]
+        [(equal? flag 'no-counterexample) 
+          (string-append prologue
+                        "\n<sig label=\"No counterexample found. Assertion may be valid.\" ID=\"4\" parentID=\"2\">\n"
+                        "<atom label=\"&#129395;\"/><atom label=\"&#127881;\"/><atom label=\"&#127882;\"/>\n"
+                        "</sig>\n"
+                        "</instance>\n</alloy>")]
         [else
 
          (define sigs-unsorted (filter

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -330,14 +330,16 @@
      #`(begin
          (define hashy (make-hash))
          (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper))) ...
-         (add-constraint (not preds)) ...
+         (add-constraint (or (not preds) ...))
+         (printf "Added check predicates! 1")
          (run-spec hashy name #,command filepath))]
     [(_ name)
      #`(begin
          (run-spec (make-hash) name #,command filepath))]
     [(_ name (preds ...))
      #`(begin
-         (add-constraint (not preds)) ...
+         (add-constraint (or (not preds) ...))
+         (printf "Added check predicates! 2") 
          (r-spec (make-hash) name #,command filepath))]
     [(_ pred ((sig lower upper) ...)) #'(error "Check statements require a unique name specification")]
     [(_ pred) #'(error "Check statements require a unique name specification")]

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -214,7 +214,7 @@
   (if (member name run-names) (error "Non-unique run name specified") (set! run-names (cons name run-names))))
 
 
-(define (run-spec hashy name command filepath)
+(define (run-spec hashy name command filepath runtype)
   (append-run name)
 
   (define intmax (expt 2 (sub1 bitwidth)))
@@ -287,7 +287,7 @@
 
   (define (get-next-model)
     (cmd [stdin] (solve))
-    (translate-from-kodkod-cli (read-solution stdout) rels inty-univ))
+    (translate-from-kodkod-cli runtype (read-solution stdout) rels inty-univ))
 
   (display-model get-next-model name command filepath bitwidth))
 
@@ -298,20 +298,20 @@
      #`(begin
          (define hashy (make-hash))
          (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper))) ...
-         (run-spec hashy name #,command filepath))]
+         (run-spec hashy name #,command filepath 'run))]
     [(_ name (preds ...) ((sig lower upper) ...))
      #`(begin
          (define hashy (make-hash))
          (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper))) ...
          (add-constraint preds) ...
-         (run-spec hashy name #,command filepath))]
+         (run-spec hashy name #,command filepath 'run))]
     [(_ name)
      #`(begin
-         (run-spec (make-hash) name #,command filepath))]
+         (run-spec (make-hash) name #,command filepath 'run))]
     [(_ name (preds ...))
      #`(begin
          (add-constraint preds) ...
-         (run-spec (make-hash) name #,command filepath))]
+         (run-spec (make-hash) name #,command filepath 'run))]
     [(_ pred ((sig lower upper) ...)) #'(error "Run statements require a unique name specification")]
     [(_ pred) #'(error "Run statements require a unique name specification")]
     [(_) #'(error "Run statements require a unique name specification")]
@@ -325,22 +325,22 @@
      #`(begin
          (define hashy (make-hash))
          (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper))) ...
-         (run-spec hashy name #,command filepath))]
+         (run-spec hashy name #,command filepath 'check))]
     [(_ name (preds ...) ((sig lower upper) ...))
      #`(begin
          (define hashy (make-hash))
          (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper))) ...
          (add-constraint (or (not preds) ...))
          (printf "Added check predicates! 1")
-         (run-spec hashy name #,command filepath))]
+         (run-spec hashy name #,command filepath 'check))]
     [(_ name)
      #`(begin
-         (run-spec (make-hash) name #,command filepath))]
+         (run-spec (make-hash) name #,command filepath 'check))]
     [(_ name (preds ...))
      #`(begin
          (add-constraint (or (not preds) ...))
          (printf "Added check predicates! 2") 
-         (r-spec (make-hash) name #,command filepath))]
+         (r-spec (make-hash) name #,command filepath 'check))]
     [(_ pred ((sig lower upper) ...)) #'(error "Check statements require a unique name specification")]
     [(_ pred) #'(error "Check statements require a unique name specification")]
     [(_) #'(error "Check statements require a unique name specification")]

--- a/forge/translate-from-kodkod-cli.rkt
+++ b/forge/translate-from-kodkod-cli.rkt
@@ -31,14 +31,18 @@ relation-names is the same, a list of all relation names ordered as they are in 
 This function just recreates the model, but using names instead of numbers.
 |#
 
-(define (translate-from-kodkod-cli model relation-names inty-univ)
+(define (translate-from-kodkod-cli runtype model relation-names inty-univ)
   (define flag (car model))
   (define data (cdr model))
   
-  (cond [(and (equal? 'unsat flag) data)
+  (cond [(and (equal? 'unsat flag) (equal? runtype 'run) data)
          (cons 'unsat data)]
-        [(and (equal? 'unsat flag) (not data))
+        [(and (equal? 'unsat flag) (equal? runtype 'run) (not data))
          (cons 'unsat #f)]
+        [(and (equal? 'unsat flag) (equal? runtype 'check) data)
+          (cons 'no-counterexample data)]
+        [(and (equal? 'unsat flag) (equal? runtype 'check) (not data))
+          (cons 'no-counterexample #f)]
         [(equal? 'no-more-instances flag)
          (cons 'no-more-instances #f)]
         [(equal? 'sat flag)

--- a/forge/translate-to-kodkod-cli.rkt
+++ b/forge/translate-to-kodkod-cli.rkt
@@ -31,6 +31,7 @@
        (interpret-formula form relations quantvars)
        ( print-cmd-cont ")"))]
     [#t ( print-cmd-cont "true ")]
+    [#f ( print-cmd-cont "false ")]
     ))
 
 (define (interpret-formula-op formula relations quantvars args)


### PR DESCRIPTION
Added in `check` construct. Decided against including `assert`, you can just use a `pred` in a check instead. Nice screen for "no counterexample found" for unsat when using a `check`. 

Essentially same as running `run {facts and not pred}` (i.e. looking for a place where facts hold true but the predicate doesn't).