### PR TITLE
add test construct

### DIFF
--- a/forge/lang/alloy-syntax/lexer.rkt
+++ b/forge/lang/alloy-syntax/lexer.rkt
@@ -70,7 +70,8 @@
    ["disj"      (token+ `DISJ-TOK "" lexeme "" lexeme-start lexeme-end)]  
    ["else"      (token+ `ELSE-TOK "" lexeme "" lexeme-start lexeme-end)]  
    ["eval"      (token+ `EVAL-TOK "" lexeme "" lexeme-start lexeme-end)]
-   ["exactly"   (token+ `EXACTLY-TOK "" lexeme "" lexeme-start lexeme-end)]    
+   ["exactly"   (token+ `EXACTLY-TOK "" lexeme "" lexeme-start lexeme-end)]   
+   ["expect"    (token+ `EXPECT-TOK "" lexeme "" lexeme-start lexeme-end)]    
    ["extends"   (token+ `EXTENDS-TOK "" lexeme "" lexeme-start lexeme-end)]    
    ["fact"      (token+ `FACT-TOK "" lexeme "" lexeme-start lexeme-end)]  
    ["for"       (token+ `FOR-TOK "" lexeme "" lexeme-start lexeme-end)]
@@ -87,11 +88,14 @@
    ["open"      (token+ `OPEN-TOK "" lexeme "" lexeme-start lexeme-end)]  
    ["pred"      (token+ `PRED-TOK "" lexeme "" lexeme-start lexeme-end)]  
    ["run"       (token+ `RUN-TOK "" lexeme "" lexeme-start lexeme-end)]
+   ["sat"       (token+ `SAT-TOK "" lexeme "" lexeme-start lexeme-end)] 
    ["set"       (token+ `SET-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["sig"       (token+ `SIG-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["some"      (token+ `SOME-TOK "" lexeme "" lexeme-start lexeme-end)]  
    ["sum"       (token+ `SUM-TOK "" lexeme "" lexeme-start lexeme-end)]
-   ["univ"      (token+ `UNIV-TOK "" lexeme "" lexeme-start lexeme-end)]  
+   ["test"      (token+ `TEST-TOK "" lexeme "" lexeme-start lexeme-end)]
+   ["univ"      (token+ `UNIV-TOK "" lexeme "" lexeme-start lexeme-end)]
+   ["unsat"     (token+ `UNSAT-TOK "" lexeme "" lexeme-start lexeme-end)]  
    ["break"     (token+ `BREAK-TOK "" lexeme "" lexeme-start lexeme-end)]  
 
    ["state"     (token+ `STATE-TOK "" lexeme "" lexeme-start lexeme-end)]
@@ -158,6 +162,10 @@
            "sig"
            "some"
            "sum"
+           "test"
+           "expect"
+           "sat"
+           "unsat"
            "univ"
            "break")))
 

--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -12,6 +12,7 @@ Import : OPEN-TOK QualName (LEFT-SQUARE-TOK QualNameList RIGHT-SQUARE-TOK)? (AS-
           | FunDecl 
           | AssertDecl 
           | CmdDecl
+          | TestDecl
           | SexprDecl
           | BreakDecl
           | InstanceDecl
@@ -33,6 +34,7 @@ ParaDecls : /LEFT-PAREN-TOK @DeclList? /RIGHT-PAREN-TOK
           | /LEFT-SQUARE-TOK @DeclList? /RIGHT-SQUARE-TOK
 AssertDecl : /ASSERT-TOK Name? Block
 CmdDecl : (Name /COLON-TOK)? (RUN-TOK | CHECK-TOK)? (QualName | Block)? Scope?
+TestDecl : (Name /COLON-TOK)? TEST-TOK (QualName | Block)? Scope? /EXPECT-TOK (SAT-TOK | UNSAT-TOK)
 Scope : /FOR-TOK Number (/BUT-TOK @TypescopeList)? 
       | /FOR-TOK @TypescopeList
 Typescope : EXACTLY-TOK? Number QualName


### PR DESCRIPTION
Syntax is just like run, but is followed by "expect (sat | unsat)".
Throws an error if the test doesn't go as expected.