### PR TITLE
add test expect blocks

### DIFF
--- a/forge/lang/alloy-syntax/lexer.rkt
+++ b/forge/lang/alloy-syntax/lexer.rkt
@@ -80,6 +80,7 @@
    ["fun"       (token+ `FUN-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["iden"      (token+ `IDEN-TOK "" lexeme "" lexeme-start lexeme-end)]      
    ["in"        (token+ `IN-TOK "" lexeme "" lexeme-start lexeme-end)]
+   ["is"        (token+ `IS-TOK "" lexeme "" lexeme-start lexeme-end)]
    ;["Int"       (token+ `INT-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["let"       (token+ `LET-TOK "" lexeme "" lexeme-start lexeme-end)]
    ["lone"      (token+ `LONE-TOK "" lexeme "" lexeme-start lexeme-end)]  
@@ -148,6 +149,7 @@
            "iff"
            "implies"
            "in"
+           "is"
            "Int"
            "let"
            "lone"

--- a/forge/lang/alloy-syntax/parser.rkt
+++ b/forge/lang/alloy-syntax/parser.rkt
@@ -12,7 +12,7 @@ Import : OPEN-TOK QualName (LEFT-SQUARE-TOK QualNameList RIGHT-SQUARE-TOK)? (AS-
           | FunDecl 
           | AssertDecl 
           | CmdDecl
-          | TestDecl
+          | TestExpectDecl
           | SexprDecl
           | BreakDecl
           | InstanceDecl
@@ -34,7 +34,9 @@ ParaDecls : /LEFT-PAREN-TOK @DeclList? /RIGHT-PAREN-TOK
           | /LEFT-SQUARE-TOK @DeclList? /RIGHT-SQUARE-TOK
 AssertDecl : /ASSERT-TOK Name? Block
 CmdDecl : (Name /COLON-TOK)? (RUN-TOK | CHECK-TOK)? (QualName | Block)? Scope?
-TestDecl : (Name /COLON-TOK)? TEST-TOK (QualName | Block)? Scope? /EXPECT-TOK (SAT-TOK | UNSAT-TOK)
+TestDecl : (Name /COLON-TOK)? (QualName | Block)? Scope? /IS-TOK (SAT-TOK | UNSAT-TOK)
+TestExpectDecl : TEST-TOK? EXPECT-TOK Name? TestBlock
+TestBlock : /LEFT-CURLY-TOK TestDecl* /RIGHT-CURLY-TOK
 Scope : /FOR-TOK Number (/BUT-TOK @TypescopeList)? 
       | /FOR-TOK @TypescopeList
 Typescope : EXACTLY-TOK? Number QualName

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -620,7 +620,7 @@
   (for ([arg (cdr d)])
     ; (println arg)
     (syntax-case arg (Name Typescope Scope Block QualName)
-      [(Name n) (set! name (syntax->datum #'n))]
+      [(Name n) (set! name (symbol->string (syntax->datum #'n)))]
       ["run"   (set! cmd 'run)]
       ["check" (set! cmd 'check)]
       ; [(? symbol? s) (set! arg (string->symbol #'s))]
@@ -647,7 +647,7 @@
   (for ([arg (cdr d)])
     ; (println arg)
     (syntax-case arg (Name Typescope Scope Block QualName)
-      [(Name n) (set! name (syntax->datum #'n))]
+      [(Name n) (set! name (symbol->string (syntax->datum #'n)))]
       ["sat" (set! expect 'sat)]
       ["unsat" (set! expect 'unsat)]
       ; [(? symbol? s) (set! arg (string->symbol #'s))]
@@ -670,7 +670,7 @@
   (for ([arg (cdr d)])
     ; (println arg)
     (syntax-case arg (Name TestBlock)
-      [(Name n) (set! name (syntax->datum #'n))]
+      [(Name n) (set! name (symbol->string (syntax->datum #'n)))]
       ["test" (set! active? #t)]
       [(TestBlock bs ...) (set! block #'(bs ...))]
       [_ #f]

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -528,7 +528,7 @@
 (require syntax/parse/define)
 (require (for-meta 1 racket/port racket/list))
 
-(provide node/int/constant ModuleDecl SexprDecl Sexpr SigDecl CmdDecl TestDecl PredDecl Block BlockOrBar
+(provide node/int/constant ModuleDecl SexprDecl Sexpr SigDecl CmdDecl TestExpectDecl TestDecl TestBlock PredDecl Block BlockOrBar
          AssertDecl BreakDecl InstanceDecl QueryDecl FunDecl ;ArrowExpr
          StateDecl TransitionDecl RelDecl
          Expr Name QualName Const Number iff ifte >= <=)
@@ -639,7 +639,7 @@
 ) stx))
 
 (define-syntax (TestDecl stx) (map-stx (lambda (d)
-  (define-values (name cmd arg scope block expect) (values #f #f #f '() #f #f))
+  (define-values (name cmd arg scope block expect) (values #f 'test #f '() #f #f))
   (define (make-typescope x)
     (syntax-case x (Typescope)
       [(Typescope "exactly" n things) (syntax->datum #'(things n n))]
@@ -648,7 +648,6 @@
     ; (println arg)
     (syntax-case arg (Name Typescope Scope Block QualName)
       [(Name n) (set! name (syntax->datum #'n))]
-      ["test" (set! cmd 'test)]
       ["sat" (set! expect 'sat)]
       ["unsat" (set! expect 'unsat)]
       ; [(? symbol? s) (set! arg (string->symbol #'s))]
@@ -666,6 +665,22 @@
   datum
 ) stx))
 
+(define-syntax (TestExpectDecl stx) (map-stx (lambda (d)
+  (define-values (name active? block) (values #f #f '()))
+  (for ([arg (cdr d)])
+    ; (println arg)
+    (syntax-case arg (Name TestBlock)
+      [(Name n) (set! name (syntax->datum #'n))]
+      ["test" (set! active? #t)]
+      [(TestBlock bs ...) (set! block #'(bs ...))]
+      [_ #f]
+    )
+  )
+  (if name #f (set! name (symbol->string (gensym))))
+  (when active?
+    (define datum `(begin ,@(syntax->datum block)))
+    datum)
+) stx))
 
 (define-syntax (PredDecl stx) (map-stx (lambda (d)
   (define-values (name paras block) (values #f '() '()))
@@ -828,6 +843,11 @@
   ;(println ret)
   ret
 )
+
+(define-syntax (TestBlock stx)
+  (define ret (syntax-case stx ()
+                [(_ b ...) #'(begin b ...)]))
+  ret)
 
 (define-syntax (Block stx)
   (define ret (syntax-case stx ()

--- a/forge/tests/basic/basicGraph.rkt
+++ b/forge/tests/basic/basicGraph.rkt
@@ -16,7 +16,7 @@ pred inNexus {
 
 
 test expect {
- {inNexus} for exactly 5 Node is sat
+ first : {inNexus} for exactly 5 Node is unsat
  {} for 5 Node is sat
  {~edges != ~(~edges)} for 5 Node is sat -- FLIP EXPECTATION TO GET PATTERN ERROR 
  {edges != ~(~edges)} for 5 Node is unsat

--- a/forge/tests/basic/basicGraph.rkt
+++ b/forge/tests/basic/basicGraph.rkt
@@ -15,32 +15,40 @@ pred inNexus {
 }
 
 
-test {inNexus} for exactly 5 Node expect sat
-test {} for 5 Node expect sat
-test {~edges != ~(~edges)} for 5 Node expect sat -- FLIP EXPECTATION TO GET PATTERN ERROR 
-test {edges != ~(~edges)} for 5 Node expect unsat
-test {edges = ^edges} for 5 Node expect sat
-test {outNexus and not inNexus} for 5 Node expect sat
-test {#Node = 4} for exactly 5 Node expect unsat
-test {#Node = 4} for 5 Node expect sat
-test {*edges != ^edges + iden} for 5 Node expect unsat
-test {edges - (edges.edges + edges.edges.edges) != edges - edges.edges - edges.edges.edges} for 7 Node expect unsat
-test {some edges - univ->univ} for 5 Node expect unsat
-test {#edges = 0} for 3 Node expect sat
-test {lone edges and no edges} for 3 Node expect sat
-test {#edges = 1} for 3 Node expect sat
-test {lone edges and one edges} for 3 Node expect sat
-test {#edges = 2} for 3 Node expect sat
-test {#edges = 3} for 3 Node expect sat
-test {#edges = 4} for 3 Node expect sat
-test {#edges = 5} for 3 Node expect sat
-test {#edges = 6} for 3 Node expect sat
-test {#edges = 7} for 3 Node expect sat
-test {#edges = 8} for 3 Node, 5 Int expect sat
-test {#edges = 9} for 3 Node, 5 Int expect sat
-test {#edges = 10} for 3 Node, 5 Int expect unsat
-test {edges = Node->Node} for 3 Node expect sat
-test {edges = iden} for 3 Node expect unsat -- because iden contains ints as well
-test {edges = iden & Node->Node} for 3 Node expect sat -- restrict to only iden on Nodes
-test {edges = iden & Node->Node and #edges != 3} for exactly 3 Node expect unsat 
+test expect {
+ {inNexus} for exactly 5 Node is sat
+ {} for 5 Node is sat
+ {~edges != ~(~edges)} for 5 Node is sat -- FLIP EXPECTATION TO GET PATTERN ERROR 
+ {edges != ~(~edges)} for 5 Node is unsat
+ {edges = ^edges} for 5 Node is sat
+ {outNexus and not inNexus} for 5 Node is sat
+ {*edges != ^edges + iden} for 5 Node is unsat
+ {edges - (edges.edges + edges.edges.edges) != edges - edges.edges - edges.edges.edges} for 7 Node is unsat
+ {some edges - univ->univ} for 5 Node is unsat
+ {#edges = 0} for 3 Node is sat
+ {lone edges and no edges} for 3 Node is sat
+ {#edges = 1} for 3 Node is sat
+ {lone edges and one edges} for 3 Node is sat
+ {edges = Node->Node} for 3 Node is sat
+ {edges = iden} for 3 Node is unsat -- because iden contains ints as well
+ {edges = iden & Node->Node} for 3 Node is sat -- restrict to only iden on Nodes
+ {edges = iden & Node->Node and #edges != 3} for exactly 3 Node is unsat
+}
+
+test expect node_cardinality {
+ {#Node = 4} for exactly 5 Node is unsat
+ {#Node = 4} for 5 Node is sat
+}
+
+test expect edges_cardinality {
+ {#edges = 2} for 3 Node is sat
+ {#edges = 3} for 3 Node is sat
+ {#edges = 4} for 3 Node is sat
+ {#edges = 5} for 3 Node is sat
+ {#edges = 6} for 3 Node is sat
+ {#edges = 7} for 3 Node is sat
+ {#edges = 8} for 3 Node, 5 Int is sat
+ {#edges = 9} for 3 Node, 5 Int is sat
+ {#edges = 10} for 3 Node, 5 Int is unsat
+} 
 

--- a/forge/tests/basic/booleanLogic.rkt
+++ b/forge/tests/basic/booleanLogic.rkt
@@ -54,11 +54,14 @@ pred GiveMeABigFormula {
   }
 }
 
+test expect gimme_big {
+ GiveMeABigFormula for 8 Formula, 2 Instance is sat
+ GiveMeABigFormula for 8 Formula, 1 Instance is unsat
+}
 
-test GiveMeABigFormula for 8 Formula, 2 Instance expect sat
-test GiveMeABigFormula for 8 Formula, 1 Instance expect unsat
-
-test {some f: Formula | f in Var and f in And} expect unsat
-test {some x: univ | x in Formula and x in Instance} expect unsat
-test {some oleft & aleft} expect unsat
-test {semantics and {some n: Not, i: Instance | i in n.truth and i in n.child.truth }} for 8 Formula, 1 Instance expect unsat
+test expect {
+ {some f: Formula | f in Var and f in And} is unsat
+ {some x: univ | x in Formula and x in Instance} is unsat
+ {some oleft & aleft} is unsat
+ {semantics and {some n: Not, i: Instance | i in n.truth and i in n.child.truth }} for 8 Formula, 1 Instance is unsat
+}

--- a/forge/tests/basic/sudoku.rkt
+++ b/forge/tests/basic/sudoku.rkt
@@ -57,9 +57,11 @@ pred solved[b: Board] {
 pred someSolved {
   some b: Board | solved[b]
 }
-test {structural} for 2 Board, 9 N expect sat
-test {tenFilled structural} for 2 Board, 9 N, 8 Int expect sat
-test {someSolved structural} for 2 Board, 9 N, 8 Int expect sat
+test expect {
+ {structural} for 2 Board, 9 N is sat
+ {tenFilled structural} for 2 Board, 9 N, 8 Int is sat
+ {someSolved structural} for 2 Board, 9 N, 8 Int is sat
+}
 
 pred generatePuzzle {
   structural
@@ -73,4 +75,6 @@ pred generatePuzzle {
     solved[final]     
   }
 } 
-test {generatePuzzle} for 2 Board, 9 N, 8 Int expect sat
+test expect {
+  generatePuzzle for 2 Board, 9 N, 8 Int is sat
+}


### PR DESCRIPTION
SYNTAX:

test? expect name? {
  (name | block) (scope)? is (sat | unsat)
}

Without the prefix "test", the block expresses the user's expectations
*without actually having the solver test them*. With the prefix "test",
every test in the block is actually tested by the solver.