### PR TITLE
Maxs & Mins & Lots galore

### DIFF
--- a/forge/lang/alloy-syntax/lexer.rkt
+++ b/forge/lang/alloy-syntax/lexer.rkt
@@ -196,6 +196,8 @@
            'subtract
            'multiply
            'divide
+           'abs
+           'sign
            'max
            'min
            "#"

--- a/forge/lang/ast.rkt
+++ b/forge/lang/ast.rkt
@@ -193,6 +193,7 @@
 (define univ (node/expr/constant 1 'univ))
 (define iden (node/expr/constant 2 'iden))
 (define Int (node/expr/relation 1 "Int" '(Int) "univ"))
+(define succ (node/expr/relation 2 "succ" '(Int Int) "CharlieSaysWhatever"))
 
 ;; INTS ------------------------------------------------------------------------
 

--- a/forge/lang/ast.rkt
+++ b/forge/lang/ast.rkt
@@ -230,8 +230,13 @@
 (define-int-op sum node/expr? #:min-length 1 #:max-length 1)
 
 (define-int-op remainder node/int? #:min-length 2 #:max-length 2)
-(define-int-op absolute node/int? #:min-length 1 #:max-length 1)
+(define-int-op abs node/int? #:min-length 1 #:max-length 1)
 (define-int-op sign node/int? #:min-length 1 #:max-length 1)
+
+(define (max s-int)
+  (sum (- s-int (join (^ succ) s-int))))
+(define (min s-int)
+  (sum (- s-int (join s-int (^ succ)))))
 
 ;(define-int-op max node/expr? #:min-length 1 #:max-length 1)
 ;(define-int-op min node/expr? #:min-length 1 #:max-length 1)
@@ -439,9 +444,9 @@
        (node/formula/op/!? op)
        (node/int/op/sum? op)
        (node/int/op/card? op)
-       (node/int/op/absolute? op)
+       (node/int/op/abs? op)
        (node/int/op/sign? op)
-       (@member op (list ~ ^ * sing ! not sum card absolute sign)))) ; These are just aliases for the expanded names
+       (@member op (list ~ ^ * sing ! not sum card abs sign)))) ; These are just aliases for the expanded names
 (define (binary-op? op)
   (@member op (list <: :> in = => int= int> int< remainder)))
 (define (nary-op? op)

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -107,7 +107,18 @@
 (define (fact form)
   (set! constraints (cons form constraints)))
 
-(provide pre-declare-sig declare-sig set-top-level-bound sigs run check test fact Int iden univ none no some one lone all + - ^ & ~ join ! set in declare-one-sig pred = -> * => not and or set-bitwidth < > add subtract multiply divide int= card sum sing)
+
+(provide pre-declare-sig declare-one-sig declare-sig set-top-level-bound sigs pred)
+(provide run check test fact)
+(provide Int iden univ none)
+(provide no some one lone all)
+(provide + - ^ & ~ join !)
+(provide set in )
+(provide = -> * => not and or)
+(provide set-bitwidth)
+(provide < > int=)
+(provide add subtract multiply divide sign abs)
+(provide card sum sing succ max min)
 (provide add-relation set-option)
 
 (define (add-relation rel types)

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -559,12 +559,16 @@
     [(_ name ((sig lower upper) ...))
      #`(begin
          (define hashy (make-hash))
-         (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper))) ...
+         (if (equal? sig Int)
+           (set-bitwidth upper)
+           (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper)))) ...
          (run-spec hashy name #,command filepath 'run))]
     [(_ name (preds ...) ((sig lower upper) ...))
      #`(begin
          (define hashy (make-hash))
-         (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper))) ...
+         (if (equal? sig Int)
+           (set-bitwidth upper)
+           (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper)))) ...
          (run-spec hashy name #,command filepath 'run preds ...))]
     [(_ name)
      #`(begin
@@ -585,12 +589,16 @@
     [(_ name ((sig lower upper) ...))
      #`(begin
          (define hashy (make-hash))
-         (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper))) ...
+         (if (equal? sig Int)
+           (set-bitwidth upper)
+           (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper)))) ...
          (run-spec hashy name #,command filepath 'check))]
     [(_ name (preds ...) ((sig lower upper) ...))
      #`(begin
          (define hashy (make-hash))
-         (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper))) ...
+         (if (equal? sig Int)
+           (set-bitwidth upper)
+           (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper)))) ...
          ; (add-constraint (or (not preds) ...))
          ;(printf "Added check predicates! 1")
          (run-spec hashy name #,command filepath 'check (or (not preds) ...)))]
@@ -613,14 +621,18 @@
     [(_ name ((sig lower upper) ...) expect)
      #`(begin
          (define hashy (make-hash))
-         (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper))) ...
+         (if (equal? sig Int)
+           (set-bitwidth upper)
+           (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper)))) ...
          (define res (run-spec hashy name #,command filepath 'test))
          (unless (equal? res expect)
            (error (format-datum '~a-~a "test" name) (format "expected ~a, got ~a in\n ~a" expect res #,command))))]
     [(_ name (preds ...) ((sig lower upper) ...) expect)
      #`(begin
          (define hashy (make-hash))
-         (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper))) ...
+         (if (equal? sig Int)
+           (set-bitwidth upper)
+           (unless (hash-has-key? int-bounds-store sig) (hash-set! hashy sig (int-bound lower upper)))) ...
          ; (add-constraint preds) ...
          (define res (run-spec hashy name #,command filepath 'test preds ...))
          (unless (equal? res expect)

--- a/forge/sigs.rkt
+++ b/forge/sigs.rkt
@@ -449,7 +449,7 @@
   (set! run-constraints (append run-constraints disj-cs))
   (define inty-univ (append int-range working-universe)) ; A universe of all possible atoms, including integers (actual values, not kodkod-cli indices)
 
-
+  ; Add integer atoms forcefully because they always exist
   (set! sig-bounds (cons (bound Int int-range-singletons int-range-singletons) sig-bounds))
   (hash-set! bounds-store Int int-range) ; Set an exact bount on Int to contain int-range
   (hash-set! upper-bounds Int int-range)
@@ -458,6 +458,11 @@
   ; Int needs to be in upper-bounds, lower-bounds, and sig-bounds
   (define total-bounds (append (map relation->bounds (hash-keys relations-store)) sig-bounds))
   (define rels (append (hash-keys relations-store) sigs (list Int)))
+
+  ; Add the successor relation on integers (and it's exact)
+  (define successor-rel (map list (take int-range (sub1 (length int-range))) (rest int-range)))
+  (set! total-bounds (append total-bounds (list (bound succ successor-rel successor-rel))))
+  (set! rels (append rels (list succ)))
 
   ; Initializing our kodkod-cli process, and getting ports for communication with it
   (define kks (new server%

--- a/forge/translate-from-kodkod-cli.rkt
+++ b/forge/translate-from-kodkod-cli.rkt
@@ -61,7 +61,7 @@ This function just recreates the model, but using names instead of numbers.
 (define (translate-from-kodkod-cli runtype model relation-names inty-univ)
   (define flag (car model))
   (define data (cdr model))
-  
+
   (cond [(and (equal? 'unsat flag) (equal? runtype 'run) data)
          (cons 'unsat data)]
         [(and (equal? 'unsat flag) (equal? runtype 'run) (not data))
@@ -83,10 +83,12 @@ This function just recreates the model, but using names instead of numbers.
 
          (for ([relation-num (hash-keys data)])
            (cond [(id-to-index relation-num)
-                  ; A declared relation
-                  (hash-set! translated-model
+                  (let ([idx (id-to-index relation-num)])
+                    (unless (string=? "succ" (relation-name (list-ref relation-names idx)))
+                      ; A declared relation
+                      (hash-set! translated-model
                              (list-ref relation-names (id-to-index relation-num))
-                             (translate-kodkod-cli-relation inty-univ (hash-ref data relation-num)))]
+                             (translate-kodkod-cli-relation inty-univ (hash-ref data relation-num)))))]
                  [else
                   ; Likely a Skolem relation. Infer arity from contents                  
                   (define tuples (hash-ref data relation-num))

--- a/forge/translate-to-kodkod-cli.rkt
+++ b/forge/translate-to-kodkod-cli.rkt
@@ -183,7 +183,7 @@
      ( print-cmd-cont "(% ")
      (map (lambda (x) (interpret-int x relations quantvars)) args)
      ( print-cmd-cont ")")]
-    [(? node/int/op/absolute?)
+    [(? node/int/op/abs?)
      ( print-cmd-cont "(abs ")
      (map (lambda (x) (interpret-int x relations quantvars)) args)
      ( print-cmd-cont ")")]


### PR DESCRIPTION
Added the following:
- `succ` (successor) relation on Int atoms
- `max[]` and `min[]` functions that take a set of int atoms and return the max/min **value**
- renamed `absolute` to `abs`

`sign` and `abs` now work! and syntax highlighting too!
