### PR TITLE
[patch] remove heap size flag

### DIFF
--- a/forge/kodkod-cli/server/server.rkt
+++ b/forge/kodkod-cli/server/server.rkt
@@ -26,10 +26,10 @@
 
     (if incremental?
         (subprocess #f #f #f
-                    java "-Xmx2G" "-cp" cp (string-append "-Djava.library.path=" (path->string kodkod/jar))
+                    java "-cp" cp (string-append "-Djava.library.path=" (path->string kodkod/jar))
                     "kodkod.cli.KodkodServer" "-incremental" "-error-out" error-out)
         (subprocess #f #f #f
-                    java "-Xmx2G" "-cp" cp (string-append "-Djava.library.path=" (path->string kodkod/jar))
+                    java "-cp" cp (string-append "-Djava.library.path=" (path->string kodkod/jar))
                     "kodkod.cli.KodkodServer" "-stepper" "-error-out" error-out))))
 
 (define (kodkod-stderr-handler src err)


### PR DESCRIPTION
Remove the "-Xmx2G" flag when we spin up a KodKod process.  Shouldn't need a 2G heap, and this seems to be the culprit of errors on machines running 32-bit Java on windows 10 machines.