### PR TITLE
[patch] LHS patch + instance Ints patch

### DIFF
--- a/forge/examples/namedAtoms.rkt
+++ b/forge/examples/namedAtoms.rkt
@@ -13,7 +13,15 @@ run {} for {
 
     r in (A-C)->B
 
+    -- incorrect but backwards compatible
     r.Alpha = Beta
     r.Aleph in Beth
     r.Ayy ni Bee
+
+    -- correct (but redundant here)
+    Alpha.r = Beta
+    Aleph.r in Beth
+    Ayy.r ni Bee
+
+    -- Ayy.Bee = Cee // ERROR: inst: one of Ayy or Bee must be a relation
 }

--- a/forge/server/eval-model.rkt
+++ b/forge/server/eval-model.rkt
@@ -161,7 +161,7 @@
 (define (->string v)
   (cond [(int-atom? v) (int-atom->string v)]
         [(symbol? v) (symbol->string v)]
-        ;[(number? v) (number->string v)]
+        [(number? v) (number->string v)]
         [else v]))
 
 ; is t1 < t2?


### PR DESCRIPTION
- fixed evaluation on Ints in RHS of instance assignments
- fixed incorrect join order for `A.B = ...` in instances. it's currently partially incorrect to maintain backwards compatibility during the L4S final projects.

don't approve this merge until 5pm today after project presentations.